### PR TITLE
Add chaos toggles to OrderService to validate Kafka compensation paths

### DIFF
--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -31,6 +31,7 @@ import org.mybatis.jpetstore.common.grpc.CatalogGrpcClient;
 import org.mybatis.jpetstore.order.repository.LineItemRepository;
 import org.mybatis.jpetstore.order.repository.OrderRepository;
 import org.mybatis.jpetstore.order.repository.SequenceRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,6 +65,15 @@ public class OrderService {
   // 첫 주문 등의 이유로 지난 주문에 대한 내역이 없는 상태
   private static final String UNPROCESSED = "unprocessed";
   private static final String COMPENSATION_TOPIC = "product_compensation";
+
+  @Value("${order.chaos.force-persist-failure:false}")
+  private boolean forcePersistFailure;
+
+  @Value("${order.chaos.skip-compensation-on-persist-failure:false}")
+  private boolean skipCompensationOnPersistFailure;
+
+  @Value("${order.chaos.check-inventory-inconsistency-on-failure:true}")
+  private boolean checkInventoryInconsistencyOnFailure;
 
 
   /**
@@ -264,14 +274,43 @@ public class OrderService {
   private void persistOrderOrCompensate(Order order, Map<String, Object> incrementPerItem)
       throws OrderFailException {
     try {
+      if (forcePersistFailure) {
+        throw new IllegalStateException("Chaos mode: forced order persistence failure");
+      }
       orderRepository.insert(order);
       orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
     } catch (Exception e) {
-      log.error("Order persistence failed. Publishing compensation transaction. orderId={}",
+      log.error("Order persistence failed. orderId={}",
           order.getOrderId(), e);
-      kafkaTemplate.send(COMPENSATION_TOPIC, incrementPerItem);
+
+      if (skipCompensationOnPersistFailure) {
+        log.error("Chaos mode: skipping compensation transaction on failure. orderId={}",
+            order.getOrderId());
+      } else {
+        kafkaTemplate.send(COMPENSATION_TOPIC, incrementPerItem);
+      }
+
+      logPotentialInventoryInconsistency(order.getOrderId());
       orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), FAIL));
-      throw new OrderFailException("주문 저장 실패로 보상 트랜잭션이 발행되었습니다.");
+      throw new OrderFailException("주문 저장에 실패했습니다.");
+    }
+  }
+
+  private void logPotentialInventoryInconsistency(int orderId) {
+    if (!checkInventoryInconsistencyOnFailure) {
+      return;
+    }
+
+    try {
+      boolean inventoryCommitSucceeded = catalogGrpcClient.isInventoryUpdateCommitSuccess(orderId);
+      if (inventoryCommitSucceeded) {
+        log.error("INVENTORY_INCONSISTENCY_DETECTED - inventory was already committed but order failed. orderId={}",
+            orderId);
+      } else {
+        log.info("Inventory update was not committed, no inconsistency detected. orderId={}", orderId);
+      }
+    } catch (Exception exception) {
+      log.warn("Failed to verify potential inventory inconsistency. orderId={}", orderId, exception);
     }
   }
 

--- a/OrderService/src/main/resources/application.yml
+++ b/OrderService/src/main/resources/application.yml
@@ -51,3 +51,8 @@ eureka:
   instance:
     prefer-ip-address: true
     instance-id: ${spring.application.name}:${server.port}
+order:
+  chaos:
+    force-persist-failure: ${ORDER_CHAOS_FORCE_PERSIST_FAILURE:false}
+    skip-compensation-on-persist-failure: ${ORDER_CHAOS_SKIP_COMPENSATION_ON_PERSIST_FAILURE:false}
+    check-inventory-inconsistency-on-failure: ${ORDER_CHAOS_CHECK_INVENTORY_INCONSISTENCY_ON_FAILURE:true}

--- a/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
+++ b/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
@@ -14,11 +14,13 @@ import org.mybatis.jpetstore.order.exception.OrderFailException;
 import org.mybatis.jpetstore.order.exception.RetryUnknownException;
 import org.mybatis.jpetstore.order.repository.OrderRepository;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -43,27 +45,17 @@ class OrderServiceTest {
     @Test
     @DisplayName("주문 저장 실패 시 Kafka 보상 메시지를 발행하고 실패 처리한다")
     void shouldCompensateAndFailWhenOrderInsertFails() throws RetryUnknownException {
-        // 1. 테스트 데이터 준비
         Order order = new Order();
         order.setOrderId(1001);
         order.setLineItems(new java.util.ArrayList<>());
 
-        // 2. Mock 설정
-        when(orderRepository.findStatus(anyInt()))
-            .thenReturn(Optional.empty());
-        
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.empty());
         when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
-
-        // 핵심: orderRepository.insert 호출 시 강제로 예외 발생
         doThrow(new RuntimeException("DB Insert Error")).when(orderRepository).insert(any(Order.class));
 
-        // 3. 테스트 실행
         assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
 
-        // 4. 검증: kafkaTemplate.send가 "product_compensation" 토픽으로 호출되었는지 확인
         verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
-        
-        // 추가 검증: 상태가 fail로 업데이트 되었는지 확인
         verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
     }
 
@@ -84,4 +76,43 @@ class OrderServiceTest {
         verify(orderRepository, never()).insert(any(Order.class));
     }
 
+    @Test
+    @DisplayName("Chaos 모드에서 주문 저장 실패를 강제로 발생시키고 보상 트랜잭션을 발행한다")
+    void shouldForcePersistFailureAndPublishCompensationInChaosMode() {
+        Order order = new Order();
+        order.setOrderId(3003);
+        order.setLineItems(new java.util.ArrayList<>());
+
+        ReflectionTestUtils.setField(orderService, "forcePersistFailure", true);
+
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.empty());
+        when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
+
+        assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
+
+        verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
+        verify(orderRepository, never()).insert(any(Order.class));
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
+    }
+
+    @Test
+    @DisplayName("Chaos 모드에서 보상 트랜잭션을 생략하면 Kafka 보상 메시지를 발행하지 않는다")
+    void shouldSkipCompensationWhenChaosFlagIsEnabled() {
+        Order order = new Order();
+        order.setOrderId(4004);
+        order.setLineItems(new java.util.ArrayList<>());
+
+        ReflectionTestUtils.setField(orderService, "forcePersistFailure", true);
+        ReflectionTestUtils.setField(orderService, "skipCompensationOnPersistFailure", true);
+
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.empty());
+        when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
+        when(catalogGrpcClient.isInventoryUpdateCommitSuccess(4004)).thenReturn(true);
+
+        assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
+
+        verify(kafkaTemplate, never()).send(eq("product_compensation"), any());
+        verify(catalogGrpcClient, times(1)).isInventoryUpdateCommitSuccess(4004);
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
+    }
 }

--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@
 - [ ] 서비스 간의 세션 공유가 적절한가? 단일 장애 지점이 되지는 않는가?
 - [ ] 다른 서비스의 로직을 참고하는 상황에서 N+1 문제가 발생하지는 않는가? API 통신이기 때문에 호출량이 많아지면 엄청난 지연이 발생 가능하다.
 - [ ] 현재와 같이 SSR일 경우에 다른 서비스의 데이터들을 조합까지 한 후 뷰를 반환하게 되면 응답 속도가 SPA에 비해 느려지지 않는가? 그렇다면 뷰를 분리할 것인가?
+
+
+## Kafka 보상 트랜잭션 Chaos 테스트 (OrderService)
+- `ORDER_CHAOS_FORCE_PERSIST_FAILURE=true` : 재고 차감 이후 Order 저장 단계에서 의도적으로 실패를 발생시킨다.
+- `ORDER_CHAOS_SKIP_COMPENSATION_ON_PERSIST_FAILURE=true` : 저장 실패 시 Kafka 보상 메시지 발행을 생략한다(재고 불일치 재현용).
+- `ORDER_CHAOS_CHECK_INVENTORY_INCONSISTENCY_ON_FAILURE=true` : 실패 시 `isInventoryUpdateCommitSuccess`를 재조회하여 불일치 여부를 로그로 남긴다.
+
+예시:
+```bash
+ORDER_CHAOS_FORCE_PERSIST_FAILURE=true \
+ORDER_CHAOS_SKIP_COMPENSATION_ON_PERSIST_FAILURE=false \
+./gradlew :OrderService:bootRun
+```
+
+보상 비활성화 시에는 OrderService 로그에 `INVENTORY_INCONSISTENCY_DETECTED`가 출력되는지 확인한다.


### PR DESCRIPTION
### Motivation
- Enable deterministic chaos testing of the compensation flow so we can verify that Kafka compensation messages are published when order persistence fails after inventory update.
- Allow an explicit mode to skip publishing the compensation message in order to reproduce and observe mid-state inventory/order inconsistencies.
- Provide a way to detect and log when inventory commit actually succeeded while order persistence failed so operators can spot inconsistent states quickly.

### Description
- Introduced three configuration flags injected with `@Value`: `order.chaos.force-persist-failure`, `order.chaos.skip-compensation-on-persist-failure`, and `order.chaos.check-inventory-inconsistency-on-failure`, and added default mappings to `OrderService/src/main/resources/application.yml`.
- Implemented chaos behavior in `OrderService.persistOrderOrCompensate(...)` to optionally force a persistence failure, conditionally skip calling `kafkaTemplate.send(...)`, and retain the normal status-update logic.
- Added a new helper `logPotentialInventoryInconsistency(int)` that calls `catalogGrpcClient.isInventoryUpdateCommitSuccess(...)` and logs `INVENTORY_INCONSISTENCY_DETECTED` when inventory was committed despite order failure.
- Extended `OrderServiceTest` with tests that cover forced persist failure, compensation publishing, and compensation skipping, and documented the runtime flags and example usage in `README.md`.

### Testing
- Added unit tests under `OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java` and attempted to run them with `./gradlew :OrderService:test --tests org.mybatis.jpetstore.order.service.OrderServiceTest`, but the automated run failed in this environment with `Unsupported class file major version 69` (Gradle/JDK incompatibility), so the tests could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad70c51890832299ffdfcbec42b7aa)